### PR TITLE
fix: removed trigger option from items

### DIFF
--- a/Assets/SWPPT3/Prefabs/Puzzle/Metal_Item.prefab
+++ b/Assets/SWPPT3/Prefabs/Puzzle/Metal_Item.prefab
@@ -65,7 +65,7 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1310564158333579539}
   m_Material: {fileID: 13400000, guid: 17fc8c5ad79d43c4f9fa923674f88ea1, type: 2}
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
   m_Size: {x: 0.4, y: 0.4, z: 0.4}

--- a/Assets/SWPPT3/Prefabs/Puzzle/Rubber_Item.prefab
+++ b/Assets/SWPPT3/Prefabs/Puzzle/Rubber_Item.prefab
@@ -65,7 +65,7 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1310564158333579539}
   m_Material: {fileID: 13400000, guid: 17fc8c5ad79d43c4f9fa923674f88ea1, type: 2}
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
   m_Size: {x: 0.4, y: 0.4, z: 0.4}


### PR DESCRIPTION
생각해보니 아이템은 바닥이랑 실제로 충돌해야 해서 trigger 체크 해제했습니다.