### PR TITLE
add: change player items to zero when collide with gas

### DIFF
--- a/Assets/SWPPT3/Scripts/Main/PlayerLogic/State/PlayerState.cs
+++ b/Assets/SWPPT3/Scripts/Main/PlayerLogic/State/PlayerState.cs
@@ -29,6 +29,10 @@ namespace SWPPT3.Main.PlayerLogic.State
             }
             else if (obstacle is Gas)
             {
+                foreach(PlayerStates playerState in System.Enum.GetValues(typeof(PlayerStates)))
+                {
+                    player.Item[playerState] = 0;
+                }
                 player.TryChangeState(PlayerStates.Slime);
             }
             else if (obstacle is MagicCircle)


### PR DESCRIPTION
Player가 gas에 충돌할 때 slime 재질로 바뀌는 것뿐만 아니라, 모든 재질 변환 횟수를 0으로 만드는 것을 구현하였습니다.